### PR TITLE
fixed wrong element value for "Fire II"

### DIFF
--- a/api/database/seeders/CreateAction.ts
+++ b/api/database/seeders/CreateAction.ts
@@ -33,7 +33,7 @@ export default class CreateActionSeeder extends BaseSeeder {
         'url': '/actions/2',
         'description': 'Deals fire damage with a potency of 100 to target and all enemies nearby it. Additional Effect: Grants Astral Fire III and removes Umbral Ice. Duration: 15s. Astral Fire Bonus: Grants Enhanced Flare. Effect is canceled if Astral Fire ends.',
         'typeId': 2,
-        'elementId': 1,
+        'elementId': 2,
         'targetId': 2,
         'aspectId': 4,
         'cast': 3,


### PR DESCRIPTION
## Fixed wrong property value in "CreateAction" seeder | d575477485a28c799a992452ef2c947d8bf7f539
### Fixed:
```Fire II```'s element property value was wrong, displaying it's element as **Ice** instead of the indended value of **Fire**.
This implementetion fix this issue by correcting the ```element_id``` value from ```1``` to ```2```