### PR TITLE
Issue#42

### DIFF
--- a/api/app/Controllers/Http/Actions/Main.ts
+++ b/api/app/Controllers/Http/Actions/Main.ts
@@ -8,6 +8,28 @@ export default class ActionsController {
     const serializedData = await data.map((data) => data.serialize({
       fields: {
         pick: ['id', 'key', 'name', 'url', 'description'],
+      },
+      relations: {
+        'type': {
+          fields: {
+            pick: ['key']
+          }
+        },
+        'target': {
+          fields: {
+            pick: ['key']
+          }
+        },
+        'element': {
+          fields: {
+            pick: ['key']
+          }
+        },
+        'aspect': {
+          fields: {
+            pick: ['key', 'name']
+          }
+        }
       }
     }))
 

--- a/api/app/Controllers/Http/Actions/Main.ts
+++ b/api/app/Controllers/Http/Actions/Main.ts
@@ -4,21 +4,18 @@ import { Action } from 'App/Models'
 export default class ActionsController {
   public async index({ }: HttpContextContract) {
     const data = await Action.query()
+
     const serializedData = await data.map((data) => data.serialize({
       fields: {
         pick: ['id', 'key', 'name', 'url', 'description'],
       }
     }))
-    
+
     return serializedData;
   }
 
   public async byId({ params }: HttpContextContract) {
-    const data = await (await Action.findByOrFail('id', params.id))
-
-    await data.load((profilerQuery) => {
-      profilerQuery.load('type').load('target').load('element').load('aspect')
-    })
+    const data = await Action.findByOrFail('id', params.id)
 
     const serializedData = data.serialize({
       fields: {

--- a/api/app/Models/Action.ts
+++ b/api/app/Models/Action.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { BaseModel, BelongsTo, belongsTo, column } from '@ioc:Adonis/Lucid/Orm'
+import { BaseModel, beforeFetch, beforeFind, BelongsTo, belongsTo, column, ModelQueryBuilderContract } from '@ioc:Adonis/Lucid/Orm'
 import { Type, Target, Element, Aspect } from '.'
 
 export default class Action extends BaseModel {
@@ -78,11 +78,15 @@ export default class Action extends BaseModel {
   @column()
   public cooldown: number
 
-
-
   @column.dateTime({ autoCreate: true, serializeAs: null })
   public createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true, serializeAs: null })
   public updatedAt: DateTime
+
+  @beforeFetch()
+  @beforeFind()
+  public static fetchRelations(query: ModelQueryBuilderContract<typeof Action>) {
+    query.preload('type').preload('target').preload('element').preload('aspect')
+  }
 }


### PR DESCRIPTION
## Added method to preload relations on 'Actions' model | 33debe7ede3149e2d226af1e2a3d250fab89cf3c
Added the 'fetchRelations' method under the ```@beforeFetch``` and ```@beforeFind``` hooks in the 'Actions' model

## Added the model relations as return values to Index controller method | 5a54c8cc19ed94c0fa8b239354e5501eb5c5afc1
Added the Actions model relationships to the return of the ```index()``` method of the Actions controller
### Added:
```Type```, ```Targets```, ```Elements```, ```Aspects```