### PR TITLE
Issue#41

### DIFF
--- a/api/app/Controllers/Http/Actions/Main.ts
+++ b/api/app/Controllers/Http/Actions/Main.ts
@@ -1,11 +1,32 @@
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 import { Action } from 'App/Models'
 
-export default class ActionsController {
-  public async index({ }: HttpContextContract) {
-    const data = await Action.query()
 
-    const serializedData = await data.map((data) => data.serialize({
+//? Function to convert query params properties from Camel Case to Snake Case
+function camelToSnake(key) {
+  var result = key.replace(/([A-Z])/g, " $1");
+  return result.split(' ').join('_').toLowerCase();
+}
+
+export default class ActionsController {
+  public async index({ request }: HttpContextContract) {
+
+    const query = Action.query()
+
+    const queryParams = Object.keys(request.qs());
+    const queryValue = Object.values(request.qs());
+
+    if (queryParams.length >= 5) {
+      // Handle query limit error
+    } else {
+      queryParams.forEach((param, p) => {
+        query.where(`${camelToSnake(param)}`, queryValue[p])
+      });
+    }
+
+    const data = await query.exec();
+
+    const serializedData = data.map((data) => data.serialize({
       fields: {
         pick: ['id', 'key', 'name', 'url', 'description'],
       },

--- a/api/app/Controllers/Http/Actions/Main.ts
+++ b/api/app/Controllers/Http/Actions/Main.ts
@@ -1,4 +1,5 @@
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import QueryHandleException from 'App/Exceptions/QueryHandleException';
 import { Action } from 'App/Models'
 
 
@@ -17,7 +18,8 @@ export default class ActionsController {
     const queryValue = Object.values(request.qs());
 
     if (queryParams.length >= 5) {
-      // Handle query limit error
+      throw new QueryHandleException(
+        `Exceeded query search parameter limit. Maximum query search limit: '${arguments.length}' parameter.`,  414, 'EXCEEDED_QUERY_PARAMS')
     } else {
       queryParams.forEach((param, p) => {
         query.where(`${camelToSnake(param)}`, queryValue[p])

--- a/api/app/Exceptions/QueryHandleException.ts
+++ b/api/app/Exceptions/QueryHandleException.ts
@@ -1,0 +1,25 @@
+import { Exception } from '@adonisjs/core/build/standalone'
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+/*
+|--------------------------------------------------------------------------
+| Exception
+|--------------------------------------------------------------------------
+|
+| The Exception class imported from `@adonisjs/core` allows defining
+| a status code and error code for every exception.
+|
+| @example
+| new QueryHandleException('message', 500, 'E_RUNTIME_EXCEPTION')
+|
+*/
+export default class QueryHandleException extends Exception {
+    public async handle(error: this, ctx: HttpContextContract) {
+        if (error.status == 414) {
+            return ctx.response.status(error.status).json({
+                httpStatusCode: error.status,
+                error: `${error.code}`,
+                message: `${error.name}: ${error.message}`
+            })
+        }
+    }
+}


### PR DESCRIPTION
## Added query parameter search | [81ec2fb](https://github.com/Binboukami/shatotto-api/pull/46/commits/81ec2fb2f9ecff6f49d79ffc3f69ec23cab0181f)
Allow users to filter search by query parameters in the url. It accepts a value in both ```camelCase``` and ```snakeCase```.
A maximum of 4 query parameters can be used in one single query - this value may change in future revisions.

### Example
**Filter actions by **elementId** and **typeId****

```.../actions?elementId=1&typeId=2```

## Added query exception handling | [13fe960](https://github.com/Binboukami/shatotto-api/pull/46/commits/13fe960bf5670c55fec814c7e8cc4f8b540eabb9)
Add exception handling for query parameter search.
Throws an error if query search exceeds the maximum accepted value of query parameters.

```
 "httpStatusCode": 414,
 "error": "EXCEEDED_QUERY_PARAMS",
 "message": "QueryHandleException: EXCEEDED_QUERY_PARAMS: Exceeded query search parameter limit. Maximum query search limit: '4' parameters."
```